### PR TITLE
麻雀の反応を柔軟に

### DIFF
--- a/plugins/mahjong_calc.py
+++ b/plugins/mahjong_calc.py
@@ -4,11 +4,12 @@ from slackbot.bot import listen_to, respond_to
 import re
 import math
 
-
-@listen_to(r'(\d+)(符|ふ)(\d+)(翻|飜|はん)(\d+)?(本場|ほんば)?')
-@listen_to(r'(\d+)(翻|飜|はん)(\d+)(符|ふ)(\d+)?(本場|ほんば)?')
-@respond_to(r'(\d+)(符|ふ)(\d+)(翻|飜|はん)(\d+)?(本場|ほんば)?')
-@respond_to(r'(\d+)(翻|飜|はん)(\d+)(符|ふ)(\d+)?(本場|ほんば)?')
+@listen_to(r'^(\d+)(,|,\s)(\d+)(,|,\s)?(\s\d+|\d+)?(\s)?')
+@listen_to(r'(\d+)(符|ふ)(\d+)(翻|飜|はん)(\s\d+|\d+)?(本場|ほんば)?')
+@listen_to(r'(\d+)(翻|飜|はん)(\d+)(符|ふ)(\s\d+|\d+)?(本場|ほんば)?')
+@respond_to(r'^(\d+)(,|,\s)(\d+)(,|,\s)?(\s\d+|\d+)?(\s)?')
+@respond_to(r'(\d+)(符|ふ)(\d+)(翻|飜|はん)(\s\d+|\d+)?(本場|ほんば)?')
+@respond_to(r'(\d+)(翻|飜|はん)(\d+)(符|ふ)(\s\d+|\d+)?(本場|ほんば)?')
 def calc(message, *params):
 
     # set hu and han
@@ -20,7 +21,7 @@ def calc(message, *params):
     if re.match('(本場|ほんば)', str(params[5])):
         homba = int(params[4])
     elif params[4] is not None:
-        message.send(params[4] + '本場で計算しますよ')
+        # message.send(params[4] + '本場で計算しますよ')
         homba = int(params[4])
     else:
         homba = 0
@@ -32,6 +33,7 @@ def calc(message, *params):
         return
 
     # round up
+    hu_orig = hu
     hu = hu if hu == 25 else math.ceil(hu / 10) * 10
 
     # calc basic point
@@ -51,12 +53,16 @@ def calc(message, *params):
     # pay
     rh = 300 * homba
     th = 100 * homba
-    msg = '```\n'\
-          '親: ' + str(ceil10(basic_point * 6) + rh) + \
+    msg = '```\n'
+    if homba > 0:
+        msg += str(han) + '飜' + str(hu_orig) + '符 ' + str(homba) + '本場\n'
+    else:
+        msg += str(han) + '飜' + str(hu_orig) + '符\n'
+    msg += '親: ' + str(ceil10(basic_point * 6) + rh) + \
           ' (' + str(ceil10(basic_point * 2) + th) + ' all)\n'\
           '子: ' + str(ceil10(basic_point * 4) + rh) + \
           ' (' + str(ceil10(basic_point * 1) + th) + \
-          ',' + str(ceil10(basic_point * 2) + th) + ')\n' + \
+          ', ' + str(ceil10(basic_point * 2) + th) + ')\n' + \
           '```'
     message.send(msg)
 


### PR DESCRIPTION
主な変更点は次の3つです．

- `4飜40符 1本場` と `4飜40符1本場` で同じ対応ができるようにした(本場の数字の前にスペースがあっても動くように)
- `4, 40, 1` とか `4, 40` とかを**文頭で**打つと反応して返してくれるようにした．文頭じゃなければ反応しないのでそこまで他のコメントに影響はないと思いますが…
- 出力の前に `4飜36符` のように入力が正しいか確認する部分を追加．また，出力が
`子: 8000 (2000, 4000)` みたいになるようにした．コンマの後ろの半角スペース．単純に自分のこだわりです